### PR TITLE
Add missing property to pom.xml. fixes #1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,10 @@
         <version>2.32</version>
     </parent>
 
+    <properties>
+        <jenkins.version>2.60.2</jenkins.version>
+    </properties>
+
     <groupId>org.kitteh.jenkins</groupId>
     <artifactId>jenkittens</artifactId>
     <version>1.0.0-SNAPSHOT</version>


### PR DESCRIPTION
According to https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial#Plugintutorial-IntelliJIDEA,
this missing property has been required since parent POM version 2.2